### PR TITLE
Add Created As Search Parameter For Announcement

### DIFF
--- a/src/main/java/com/gf/st/ab/domain/AnnouncementRepository.java
+++ b/src/main/java/com/gf/st/ab/domain/AnnouncementRepository.java
@@ -4,6 +4,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
+import java.util.Date;
+
 /**
  * @author Rashidi Zin
  */
@@ -16,4 +18,6 @@ public interface AnnouncementRepository extends MongoRepository<Announcement, St
     Page<Announcement> findAllByTitleContainsIgnoreCase(String title, Pageable pageable);
 
     Page<Announcement> findAllByContentContainsIgnoreCase(String content, Pageable pageable);
+
+    Page<Announcement> findAllByCreatedAfter(Date created, Pageable pageable);
 }

--- a/src/main/java/com/gf/st/ab/service/AnnouncementService.java
+++ b/src/main/java/com/gf/st/ab/service/AnnouncementService.java
@@ -12,6 +12,7 @@ import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
+import java.util.Date;
 
 import static org.springframework.util.Assert.hasLength;
 
@@ -46,7 +47,7 @@ public class AnnouncementService {
         return repository.findAll(pageable);
     }
 
-    public Page<Announcement> search(String title, String content, String userId, String username, Pageable pageable) {
+    public Page<Announcement> search(String title, String content, String userId, String username, Date created, Pageable pageable) {
 
         if (StringUtils.hasText(userId)) { return repository.findAllByUserId(userId, pageable); }
 
@@ -55,6 +56,8 @@ public class AnnouncementService {
         else if (StringUtils.hasText(title)) { return repository.findAllByTitleContainsIgnoreCase(title, pageable); }
 
         else if (StringUtils.hasText(content)) { return repository.findAllByContentContainsIgnoreCase(content, pageable); }
+
+        else if (created != null) { return repository.findAllByCreatedAfter(created, pageable); }
 
         return new PageImpl<Announcement>(new ArrayList<Announcement>());
     }

--- a/src/main/java/com/gf/st/ab/web/AnnouncementController.java
+++ b/src/main/java/com/gf/st/ab/web/AnnouncementController.java
@@ -8,11 +8,14 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Date;
 
 import static org.springframework.http.HttpStatus.*;
 import static org.springframework.web.bind.annotation.RequestMethod.*;
@@ -67,11 +70,12 @@ public class AnnouncementController {
     @RequestMapping(value = "search", method = GET)
     public ResponseEntity<Page<Announcement>> getWithCriteria(@RequestParam(value = "title", required = false) String title, @RequestParam(value = "content", required = false) String content,
                                                               @RequestParam(value = "userId", required = false) String userId, @RequestParam(value = "username", required = false) String username,
+                                                              @RequestParam(value = "created", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Date created,
                                                               @RequestParam(value = "page", required = false, defaultValue = "0") int page, @RequestParam(value = "size", required = false, defaultValue = "25") int size) {
 
         Pageable pageable = new PageRequest(page, size, Sort.Direction.DESC, "created");
 
-        return new ResponseEntity<Page<Announcement>>(service.search(title, content, userId, username, pageable), OK);
+        return new ResponseEntity<Page<Announcement>>(service.search(title, content, userId, username, created, pageable), OK);
     }
 
     @RequestMapping(value = "{id}", method = DELETE)

--- a/src/test/java/com/gf/st/ab/domain/AnnouncementRepositoryTest.java
+++ b/src/test/java/com/gf/st/ab/domain/AnnouncementRepositoryTest.java
@@ -8,6 +8,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
+import java.util.Calendar;
+import java.util.Date;
+
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -60,9 +64,34 @@ public class AnnouncementRepositoryTest extends AbstractTests {
         );
     }
 
+    @Test
+    public void findAllByCreatedAfter() {
+        assertFalse(
+                $.findAllByCreatedAfter(announcement.getCreated(), pageable).hasContent()
+        );
+
+        Announcement persisted = $.findOne(announcement.getId());
+        Date futureDate = getFutureDate(persisted.getCreated(), 2);
+
+        persisted.setCreated(futureDate);
+        $.save(persisted);
+
+        assertTrue(
+                $.findAllByCreatedAfter(announcement.getCreated(), pageable).hasContent()
+        );
+    }
+
     @After
     public void delete() {
         $.delete(announcement);
         userRepository.delete(user);
+    }
+
+    private Date getFutureDate(Date date, int amountOfDays) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(date);
+        calendar.add(Calendar.DATE, amountOfDays);
+
+        return calendar.getTime();
     }
 }

--- a/src/test/java/com/gf/st/ab/service/AnnouncementServiceTest.java
+++ b/src/test/java/com/gf/st/ab/service/AnnouncementServiceTest.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import java.util.ArrayList;
+import java.util.Date;
 
 import static org.mockito.Mockito.*;
 
@@ -92,7 +93,7 @@ public class AnnouncementServiceTest extends AbstractMockTests {
     public void searchByUserId() {
         when(repository.findAllByUserId(user.getId(), pageable)).thenReturn(searchResult);
 
-        $.search(null, null, user.getId(), null, pageable);
+        $.search(null, null, user.getId(), null, null, pageable);
 
         verify(repository).findAllByUserId(user.getId(), pageable);
         verify(repository, times(0)).findAllByUsername(user.getUsername(), pageable);
@@ -104,7 +105,7 @@ public class AnnouncementServiceTest extends AbstractMockTests {
     public void searchByUserName() {
         when(repository.findAllByUsername(user.getUsername(), pageable)).thenReturn(searchResult);
 
-        $.search(null, null, null, user.getUsername(), pageable);
+        $.search(null, null, null, user.getUsername(), null, pageable);
 
         verify(repository).findAllByUsername(user.getUsername(), pageable);
         verify(repository, times(0)).findAllByUserId(user.getId(), pageable);
@@ -116,7 +117,7 @@ public class AnnouncementServiceTest extends AbstractMockTests {
     public void searchByTitle() {
         when(repository.findAllByTitleContainsIgnoreCase(announcement.getTitle(), pageable)).thenReturn(searchResult);
 
-        $.search(announcement.getTitle(), null, null, null, pageable);
+        $.search(announcement.getTitle(), null, null, null, null, pageable);
 
         verify(repository).findAllByTitleContainsIgnoreCase(announcement.getTitle(), pageable);
         verify(repository, times(0)).findAllByUsername(user.getUsername(), pageable);
@@ -128,7 +129,7 @@ public class AnnouncementServiceTest extends AbstractMockTests {
     public void searchByContent() {
         when(repository.findAllByContentContainsIgnoreCase(announcement.getTitle(), pageable)).thenReturn(searchResult);
 
-        $.search(null, announcement.getContent(), null, null, pageable);
+        $.search(null, announcement.getContent(), null, null, null, pageable);
 
         verify(repository).findAllByContentContainsIgnoreCase(announcement.getContent(), pageable);
         verify(repository, times(0)).findAllByUserId(user.getId(), pageable);
@@ -138,8 +139,23 @@ public class AnnouncementServiceTest extends AbstractMockTests {
 
     @Test
     public void searchWithoutParameter() {
-        $.search(null, null, null, null, pageable);
+        $.search(null, null, null, null, null, pageable);
 
+        verify(repository, times(0)).findAllByUserId(user.getId(), pageable);
+        verify(repository, times(0)).findAllByUsername(user.getUsername(), pageable);
+        verify(repository, times(0)).findAllByTitleContainsIgnoreCase(announcement.getTitle(), pageable);
+        verify(repository, times(0)).findAllByContentContainsIgnoreCase(announcement.getContent(), pageable);
+    }
+
+    @Test
+    public void searchByCreated() {
+        Date created = new Date();
+
+        when(repository.findAllByCreatedAfter(created, pageable)).thenReturn(searchResult);
+
+        $.search(null, null, null, null, created, pageable);
+
+        verify(repository).findAllByCreatedAfter(created, pageable);
         verify(repository, times(0)).findAllByUserId(user.getId(), pageable);
         verify(repository, times(0)).findAllByUsername(user.getUsername(), pageable);
         verify(repository, times(0)).findAllByTitleContainsIgnoreCase(announcement.getTitle(), pageable);


### PR DESCRIPTION
By providing a created date, client will be allow to search for announcements that are created after the provided date. For example by providing `2014-01-01 23:59:59` the client will retrieve list of announcements created after `2014-01-01 23:59:59`.

This is potentially useful should we decided to drop websocket support.

Fixes gh-21.