### PR TITLE
Refactor Websocket

### DIFF
--- a/src/main/java/com/gf/st/ab/configuration/AnnouncementWebSocketMessageBrokerConfigurer.java
+++ b/src/main/java/com/gf/st/ab/configuration/AnnouncementWebSocketMessageBrokerConfigurer.java
@@ -1,0 +1,26 @@
+package com.gf.st.ab.configuration;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.AbstractWebSocketMessageBrokerConfigurer;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+
+/**
+ * @author Rashidi Zin
+ */
+@Configuration
+@EnableWebSocketMessageBroker
+public class AnnouncementWebSocketMessageBrokerConfigurer extends AbstractWebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/announce").withSockJS();
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/announcements");
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+}

--- a/src/main/java/com/gf/st/ab/configuration/AnnouncementWebSocketMessageBrokerConfigurer.java
+++ b/src/main/java/com/gf/st/ab/configuration/AnnouncementWebSocketMessageBrokerConfigurer.java
@@ -15,12 +15,12 @@ public class AnnouncementWebSocketMessageBrokerConfigurer extends AbstractWebSoc
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/announce").withSockJS();
+        registry.addEndpoint("/websocket/tracker").withSockJS();
     }
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        registry.enableSimpleBroker("/announcements");
+        registry.enableSimpleBroker("/topic");
         registry.setApplicationDestinationPrefixes("/app");
     }
 }

--- a/src/main/java/com/gf/st/ab/web/AnnouncementController.java
+++ b/src/main/java/com/gf/st/ab/web/AnnouncementController.java
@@ -10,8 +10,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
-import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
@@ -37,8 +35,6 @@ public class AnnouncementController {
     AnnouncementService service;
 
     @RequestMapping(method = {POST, PUT})
-    @MessageMapping("/announce")
-    @SendTo("/announcements")
     public ResponseEntity<Announcement> create(@RequestBody Announcement announcement) {
         User loggedInUser = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 

--- a/src/main/java/com/gf/st/ab/web/AnnouncementController.java
+++ b/src/main/java/com/gf/st/ab/web/AnnouncementController.java
@@ -9,6 +9,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
@@ -32,6 +34,8 @@ public class AnnouncementController {
     AnnouncementService service;
 
     @RequestMapping(method = {POST, PUT})
+    @MessageMapping("/announce")
+    @SendTo("/announcements")
     public ResponseEntity<Announcement> create(@RequestBody Announcement announcement) {
         User loggedInUser = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 

--- a/src/main/java/com/gf/st/ab/web/websocket/AnnouncementListener.java
+++ b/src/main/java/com/gf/st/ab/web/websocket/AnnouncementListener.java
@@ -1,0 +1,34 @@
+package com.gf.st.ab.web.websocket;
+
+import com.gf.st.ab.domain.Announcement;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationListener;
+import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Controller;
+
+/**
+ * @author Rashidi Zin
+ */
+@Controller
+public class AnnouncementListener implements ApplicationListener<AfterSaveEvent> {
+
+    @Autowired
+    SimpMessageSendingOperations messagingTemplate;
+
+    @MessageMapping("/websocket/tracker")
+    @SendTo("/topic/announcements")
+    public Announcement receiveActivity(Announcement announcement) {
+        return announcement;
+    }
+
+    @Override
+    public void onApplicationEvent(AfterSaveEvent event) {
+        if (event.getSource() instanceof Announcement) {
+            Announcement announcement = (Announcement) event.getSource();
+            messagingTemplate.convertAndSend("/topic/announcements", announcement);
+        }
+    }
+}

--- a/src/main/resources/static/announcement.html
+++ b/src/main/resources/static/announcement.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+    <head></head>
+    <body ng-app="announcementBoardApp">
+        <div ng-controller="TrackerController">
+            <form ng-submit="addAnnouncement()" name="announcementForm">
+                <input type="text" placeholder="Title of your announcement" ng-model="announcementTitle" />
+                <textarea ng-mode="announcement" placeholder="Say something very long"></textarea>
+                <button>Announce!</button>
+            </form>
+            <hr />
+            <p ng-repeat="announcement in announcements | orderBy: 'created':true">
+                <time>{{ announcement.created | date:'dd-MM-yyyy HH:mm' }}</time>
+                <span>announcement.username</span>
+                <span>announcement.title</span>
+                <span>announcement.content</span>
+            </p>
+        </div>
+        <script src="bower_components/sockjs-client/dist/sockjs.js"></script>
+        <script src="bower_components/stomp-websocket/lib/stomp.min.js"></script>
+        <script src="bower_components/angular/angular.min.js"></script>
+        <script src="js/announcement-app.js" type="text/javascript"></script>
+        <script src="js/announcement-controller.js" type="text/javascript"></script>
+    </body>
+</html>

--- a/src/main/resources/static/js/announcement-app.js
+++ b/src/main/resources/static/js/announcement-app.js
@@ -1,0 +1,7 @@
+angular.module("announcementBoardApp", [
+    "announcementBoardApp.controllers",
+    "announcementBoardApp.services"
+]);
+
+angular.module("announcementBoardApp.controllers", []);
+angular.module("announcementBoardApp.services", []);

--- a/src/main/resources/static/js/announcement-controller.js
+++ b/src/main/resources/static/js/announcement-controller.js
@@ -1,0 +1,16 @@
+angular.module('announcementBoardApp').controller('TrackerController', function($scope) {
+    
+    $scope.announcements = [];
+    var socket = new SockJS("/announcement-board/websocket/tracker");
+    var stompClient = Stomp.over(socket);
+    
+    stompClient.connect({}, function(frame) {
+        stompClient.subscribe('/topic/announcements', function(announcement) {
+            showAnnouncement(announcement);
+        });
+    });
+    
+    function showAnnouncement(announcement) {
+        console.log(announcement);
+    };
+});


### PR DESCRIPTION
Currently websocket is being implemented with assumption that it can work with REST. However this is not true as websocket does not have any request method (`POST`, `PUT`, `GET`, `DELETE`). Therefore websocket configuration in `AnnouncementController` being taken out and being turned into a listener, `AnnouncementListener`.

`AnnouncementListener` is responsible to notify clients via websocket whenever an announcement is successfully saved into the database. A sample HTML and javascript is included. However please remember to remove them in the final product.

Fixes gh-20.