### PR TITLE
Fix broken layout

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Feb 12 18:26:08 SGT 2015
+#Fri Mar 13 11:02:07 SGT 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.1-all.zip

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -37,18 +37,6 @@
   </div>
 </div>
 
-
-<!-- Google Analytics: change UA-XXXXX-X to be your site's ID -->
-<script>
-       !function(A,n,g,u,l,a,r){A.GoogleAnalyticsObject=l,A[l]=A[l]||function(){
-       (A[l].q=A[l].q||[]).push(arguments)},A[l].l=+new Date,a=n.createElement(g),
-       r=n.getElementsByTagName(g)[0],a.src=u,r.parentNode.insertBefore(a,r)
-       }(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-       ga('create', 'UA-XXXXX-X');
-       ga('send', 'pageview');
-    </script>
-
 <!-- build:js(.) scripts/vendor.js -->
 <!-- bower:js -->
 <script src="bower_components/angular/angular.js"></script>

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="no-js">
+<html class="no-js" ng-app="announcementBoardApp">
 <head>
   <meta charset="utf-8">
   <title>Annoucement Board</title>
@@ -16,7 +16,7 @@
   <link rel="stylesheet" href="app/styles/main.css">
   <!-- endbuild -->
 </head>
-<body ng-app="announcementBoardApp">
+<body>
 <!--[if lt IE 7]>
 <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
 <![endif]-->

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -8,7 +8,6 @@
   <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
   <!-- build:css(.) styles/vendor.css -->
   <!-- bower:css -->
-  <link rel="stylesheet" href="bower_components/bootstrap/dist/css/bootstrap.css" />
   <link rel="stylesheet" href="bower_components/angular-material/angular-material.css"/>
   <!-- endbower -->
   <!-- endbuild -->
@@ -22,31 +21,10 @@
 <![endif]-->
 
 <!-- Add your site or application content here -->
-<div class="header">
-  <div class="navbar navbar-default" role="navigation">
-    <div class="container">
-      <div class="navbar-header">
-
-        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#js-navbar-collapse">
-          <span class="sr-only">Toggle navigation</span>
-          <span class="icon-bar"></span>
-          <span class="icon-bar"></span>
-          <span class="icon-bar"></span>
-        </button>
-
-        <a class="navbar-brand" href="#/">announcementBoard</a>
-      </div>
-
-      <div class="collapse navbar-collapse" id="js-navbar-collapse">
-
-        <ul class="nav navbar-nav">
-          <li class="active"><a href="#/">Home</a></li>
-          <li><a ng-href="#/about">About</a></li>
-          <li><a ng-href="#/">Contact</a></li>
-        </ul>
-      </div>
-    </div>
-  </div>
+<div class="header" layout="column" ng-controller="HeaderCtrl">
+  <md-toolbar>
+    <h2 class="md-toolbar-tools">Announcement Board</h2>
+  </md-toolbar>
 </div>
 
 <div class="container">
@@ -73,11 +51,8 @@
 
 <!-- build:js(.) scripts/vendor.js -->
 <!-- bower:js -->
-<script src="bower_components/jquery/dist/jquery.js"></script>
-<script src="bower_components/jquery/form-validator/jquery.form-validator.min.js"></script>
 <script src="bower_components/angular/angular.js"></script>
 <script src="bower_components/angular-aria/angular-aria.js"></script>
-<script src="bower_components/bootstrap/dist/js/bootstrap.js"></script>
 <script src="bower_components/angular-animate/angular-animate.js"></script>
 <script src="bower_components/angular-resource/angular-resource.js"></script>
 <script src="bower_components/angular-route/angular-route.js"></script>
@@ -86,10 +61,7 @@
 <!-- endbuild -->
 
 <!-- build:js({.tmp,app}) scripts/scripts.js -->
-<script src="app/scripts/app.js"></script>
-<script src="app/scripts/services.js"></script>
-<script src="app/scripts/controllers/main.js"></script>
-<script src="app/scripts/controllers/about.js"></script>
+<script src="js/controllers.js"></script>
 <!-- endbuild -->
 </body>
 </html>

--- a/src/main/resources/static/js/controllers.js
+++ b/src/main/resources/static/js/controllers.js
@@ -7,5 +7,5 @@ module.config(function($mdThemingProvider) {
         .primaryPalette('deep-orange');
 });
 
-module.controller('ApplicationCtrl', ['$scope', function($scope) {
+module.controller('HeaderCtrl', ['$scope', function($scope) {
 }]);


### PR DESCRIPTION
Commit de4c5c15b9b9ba9e83329227412688990800d2e3 which seems to be a copy-and-paste from generated code has caused the layout to be broken.

Actions being take are:

- Redefine ng-app at HTML level instead of body
- Remove non-existed scripts
- Include `controllers.js` which was being removed without any justification
- Remove Google Analytics entry. We definitely don't need it.

Fixes gh-28.