### PR TITLE
Include bower install in build process

### DIFF
--- a/bower.gradle
+++ b/bower.gradle
@@ -1,0 +1,10 @@
+apply plugin: 'com.moowork.node'
+apply plugin: 'grunt'
+
+task bower(dependsOn: 'npmInstall', type: NodeTask){
+    script = file('node_modules/bower/bin/bower')
+    args = ['install']
+}
+
+
+processResources.dependsOn 'bower'

--- a/build.gradle
+++ b/build.gradle
@@ -6,11 +6,14 @@ buildscript {
     }
     repositories {
         mavenCentral()
+        jcenter()
     }
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
         classpath('net.saliman:gradle-cobertura-plugin:2.0.0')
         classpath('org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.3.1')
+        classpath('com.moowork.gradle:gradle-node-plugin:0.8')
+        classpath('com.moowork.gradle:gradle-grunt-plugin:0.6')
     }
 }
 
@@ -27,6 +30,7 @@ war {
     version = '0.0.1-SNAPSHOT'
     archiveName = 'announcement-board.war'
 }
+
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
@@ -67,5 +71,7 @@ processResources {
             "db.password": project.property("db.password")
     ]
 }
+
+apply from: 'bower.gradle'
 
 cobertura.coverageFormats = ['html', 'xml']


### PR DESCRIPTION
Introduce `bower.gradle` which is responsible only for npm and bower related task. And it will be referred by `build.gradle`.

Add new plugins and `jcenter` repository to retrieve npm related plugins.

See gh-31.