### PR TITLE
Add badge for devDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# Announcement Board [![Build Status](https://travis-ci.org/StarTrackDevKL/announcement-board.svg?branch=develop)](https://travis-ci.org/StarTrackDevKL/announcement-board) [![Coverage Status](https://coveralls.io/repos/StarTrackDevKL/announcement-board/badge.svg?branch=develop)](https://coveralls.io/r/StarTrackDevKL/announcement-board?branch=develop)
+# Announcement Board 
+
+[![Build Status](https://travis-ci.org/StarTrackDevKL/announcement-board.svg?branch=develop)](https://travis-ci.org/StarTrackDevKL/announcement-board) 
+[![Coverage Status](https://coveralls.io/repos/StarTrackDevKL/announcement-board/badge.svg?branch=develop)](https://coveralls.io/r/StarTrackDevKL/announcement-board?branch=develop)
+[![devDependency Status](https://david-dm.org/StarTrackDevKL/announcement-board/dev-status.svg?style=flat)](https://david-dm.org/StarTrackDevKL/announcement-board#info=devDependencies)
+___
+
 Send and receive announcements in real time.
 
 ## Background

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # Announcement Board 
+Send and receive announcements in real time.
 
 [![Build Status](https://travis-ci.org/StarTrackDevKL/announcement-board.svg?branch=develop)](https://travis-ci.org/StarTrackDevKL/announcement-board) 
 [![Coverage Status](https://coveralls.io/repos/StarTrackDevKL/announcement-board/badge.svg?branch=develop)](https://coveralls.io/r/StarTrackDevKL/announcement-board?branch=develop)
 [![devDependency Status](https://david-dm.org/StarTrackDevKL/announcement-board/dev-status.svg?style=flat)](https://david-dm.org/StarTrackDevKL/announcement-board#info=devDependencies)
 ___
 
-Send and receive announcements in real time.
 
 ## Background
 An initiative taken by the Star Track Developers in Kuala Lumpur to gain experience with [AngularJS](https://angularjs.org/) and [MongoDB](http://www.mongodb.org/).
 
 ## Badges
-Badges in this README are pointing to [develop](https://github.com/StarTrackDevKL/announcement-board/tree/develop).
+Badges in this README are pointing to [develop](https://github.com/StarTrackDevKL/announcement-board/tree/develop) except for *devDependencies* which points to current branch.
 
 ## Components
 We are using several open source components:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
-# Announcement Board [![Build Status](https://travis-ci.org/StarTrackDevKL/announcement-board.svg?branch=develop)](https://travis-ci.org/StarTrackDevKL/announcement-board) [![Coverage Status](https://coveralls.io/repos/StarTrackDevKL/announcement-board/badge.svg?branch=develop)](https://coveralls.io/r/StarTrackDevKL/announcement-board?branch=develop) [![devDependency Status](https://david-dm.org/StarTrackDevKL/announcement-board/dev-status.svg?style=flat)](https://david-dm.org/StarTrackDevKL/announcement-board#info=devDependencies)
-Send and receive announcements in real time. 
+# Announcement Board 
+Send and receive announcements in real time.
 
 ## Background
 An initiative taken by the Star Track Developers in Kuala Lumpur to gain experience with [AngularJS](https://angularjs.org/) and [MongoDB](http://www.mongodb.org/).
 
 ## Badges
+[![Build Status](https://travis-ci.org/StarTrackDevKL/announcement-board.svg?branch=develop)](https://travis-ci.org/StarTrackDevKL/announcement-board) 
+[![Coverage Status](https://coveralls.io/repos/StarTrackDevKL/announcement-board/badge.svg?branch=develop)](https://coveralls.io/r/StarTrackDevKL/announcement-board?branch=develop)
+[![devDependency Status](https://david-dm.org/StarTrackDevKL/announcement-board/dev-status.svg?style=flat)](https://david-dm.org/StarTrackDevKL/announcement-board#info=devDependencies)
+
 Badges in this README are pointing to [develop](https://github.com/StarTrackDevKL/announcement-board/tree/develop) except for *devDependencies* which points to current branch.
 
 ## Components

--- a/README.md
+++ b/README.md
@@ -1,11 +1,5 @@
-# Announcement Board 
-Send and receive announcements in real time.
-
-[![Build Status](https://travis-ci.org/StarTrackDevKL/announcement-board.svg?branch=develop)](https://travis-ci.org/StarTrackDevKL/announcement-board) 
-[![Coverage Status](https://coveralls.io/repos/StarTrackDevKL/announcement-board/badge.svg?branch=develop)](https://coveralls.io/r/StarTrackDevKL/announcement-board?branch=develop)
-[![devDependency Status](https://david-dm.org/StarTrackDevKL/announcement-board/dev-status.svg?style=flat)](https://david-dm.org/StarTrackDevKL/announcement-board#info=devDependencies)
-___
-
+# Announcement Board [![Build Status](https://travis-ci.org/StarTrackDevKL/announcement-board.svg?branch=develop)](https://travis-ci.org/StarTrackDevKL/announcement-board) [![Coverage Status](https://coveralls.io/repos/StarTrackDevKL/announcement-board/badge.svg?branch=develop)](https://coveralls.io/r/StarTrackDevKL/announcement-board?branch=develop) [![devDependency Status](https://david-dm.org/StarTrackDevKL/announcement-board/dev-status.svg?style=flat)](https://david-dm.org/StarTrackDevKL/announcement-board#info=devDependencies)
+Send and receive announcements in real time. 
 
 ## Background
 An initiative taken by the Star Track Developers in Kuala Lumpur to gain experience with [AngularJS](https://angularjs.org/) and [MongoDB](http://www.mongodb.org/).


### PR DESCRIPTION
Included a badge regarding the status of our node devDependencies. This is managed by [David](david-dm.org).

Badges are now placed under **Badges** header as putting it at the first header will cause a line break.

See gh-26.