### PR TITLE
Fix broken Authorization

### DIFF
--- a/src/main/resources/static/js/AuthorizationController.js
+++ b/src/main/resources/static/js/AuthorizationController.js
@@ -21,7 +21,7 @@ module.controller('LoginCtrl', ['$scope', '$location', '$mdToast', 'store', 'Sco
                 $scope.showSimpleToast('There is an ERROR! You are not authorized for login!');
              } else {
                 $scope.loginMessages = {usernamePassword: false};
-                store.set('authorization', {username: response.username, token: response.token});
+                store.set('authorization', "Basic "+ window.btoa(response.username +":"+ response.token));
                 $scope.showSimpleToast('You are successfully logged in!');
                 angular.copy({}, auth);
                 $scope.loggedIn = true;

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -73,17 +73,17 @@ app.config(['$routeProvider', '$httpProvider', '$mdThemingProvider', function ($
             request: function(config) {
       //          delete $rootScope.errorKey;
                 var currentAuthorization = store.get('authorization');
-                var access_token = currentAuthorization ? currentAuthorization.token : null;
+                var access_token = currentAuthorization ? currentAuthorization : null;
 
                 if (access_token) {
                     config.headers.authorization = access_token;
                 }
 
-              if(!/\.html/.test(config.url)) {
-                  var defer = $q.defer();
-                  currentRequests.push(defer);
-                  config.timeout = defer.promise;
-              }
+                if(!/\.html/.test(config.url)) {
+                    var defer = $q.defer();
+                    currentRequests.push(defer);
+                    config.timeout = defer.promise;
+                }
 
                 return config;
             },


### PR DESCRIPTION
Previous implementation of authorization is wrong as it did not indicate the type of Authorization. The server is expecting `Authorization: Basic <encoded-string>`. However the Authorization header being passed was without `Basic` and it was not encoded.

This fix introduce encoded string which consists of the username and the token.

Closes gh-38