### PR TITLE
Fix Broken Travis Build

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -35,8 +35,6 @@
     "angular-mocks": "~1.3.14",
     "angular-resource": "~1.3.14",
     "angular-messages": "~1.3.15",
-    "a0-angular-storage": "~0.0.9",
-    "angular-bootstrap": "~0.12.1",
-    "bootstrap": "~3.3.4"
+    "a0-angular-storage": "~0.0.9"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -35,6 +35,7 @@
     "angular-mocks": "~1.3.14",
     "angular-resource": "~1.3.14",
     "angular-messages": "~1.3.15",
-    "a0-angular-storage": "~0.0.9"
+    "a0-angular-storage": "~0.0.9",
+    "mdi": "~1.0.62-beta"
   }
 }

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -9,7 +9,6 @@
     <!-- build:css(.) styles/vendor.css -->
     <!-- bower:css -->
     <link rel="stylesheet" href="bower_components/angular-material/angular-material.min.css"/>
-    <link rel="stylesheet" href="bower_components/bootstrap/dist/css/bootstrap.min.css">
     <!-- endbower -->
     <!-- endbuild -->
     <!-- build:css(.tmp) styles/main.css -->
@@ -84,7 +83,6 @@
 <!-- build:js(.) scripts/vendor.js -->
 <!-- bower:js -->
 <script src="bower_components/angular/angular.js"></script>
-<script src="bower_components/angular-bootstrap/ui-bootstrap-tpls.min.js"></script>
 <script src="bower_components/angular-aria/angular-aria.js"></script>
 <script src="bower_components/angular-animate/angular-animate.js"></script>
 <script src="bower_components/angular-resource/angular-resource.js"></script>

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -9,6 +9,7 @@
     <!-- build:css(.) styles/vendor.css -->
     <!-- bower:css -->
     <link rel="stylesheet" href="bower_components/angular-material/angular-material.min.css"/>
+    <link rel="stylesheet" href="bower_components/mdi/css/materialdesignicons.min.css" media="all" type="text/css" />
     <!-- endbower -->
     <!-- endbuild -->
     <!-- build:css(.tmp) styles/main.css -->

--- a/src/main/resources/static/js/AuthorizationController.js
+++ b/src/main/resources/static/js/AuthorizationController.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var module = angular.module('announcementBoardApp.AuthorizationController',['ui.bootstrap', 'ngMdIcons']);
+var module = angular.module('announcementBoardApp.AuthorizationController',[]);
 
 module.controller('LoginCtrl', ['$scope', '$location', '$mdToast', 'store', 'Scopes', 'Authorization', function($scope, $location, $mdToast, store, Scopes, Authorization) {
 

--- a/src/main/resources/static/views/profile.html
+++ b/src/main/resources/static/views/profile.html
@@ -1,8 +1,7 @@
-<div class="btn-group" dropdown is-open="status.isopen">
-    <button type="button" class="btn btn-primary dropdown-toggle" dropdown-toggle ng-disabled="disabled">
-        <ng-md-icon icon="person" style="fill: lightgreen" size="16"></ng-md-icon> {{profile.username}} <span class="caret"></span>
-    </button>
-    <ul class="dropdown-menu" role="menu">
-        <li class="dropdown-menu-clickable"><a ng-click="submitUserLogout()">Log Out</a></li>
-    </ul>
+<div>
+    <md-button class="md-fab md-primary" aria-label="logout" ng-click="submitUserLogout()">
+        <svg style="width:24px;height:24px" viewBox="0 0 24 24">
+            <path fill="#000000" d="M17,17.25V14H10V10H17V6.75L22.25,12L17,17.25M13,2A2,2 0 0,1 15,4V8H13V4H4V20H13V16H15V20A2,2 0 0,1 13,22H4A2,2 0 0,1 2,20V4A2,2 0 0,1 4,2H13Z" />
+        </svg>
+    </md-button>
 </div>


### PR DESCRIPTION
Travis was failed to build due to unsuitable version of angular that being used with angular-bootstrap. As a solution all dependencies on angular-bootstrap and bootstrap has been removed.

I find this a better option as angular-bootstrap is only being used for its dropdown feature and nothing else.

As a replacement logout icon from [mdi](http://materialdesignicons.com/) and a normal link being used.

Fixes gh-51.